### PR TITLE
Add raw_touch() feature to also return pressure and timing data

### DIFF
--- a/cydr.py
+++ b/cydr.py
@@ -222,6 +222,25 @@ class CYD(object):
 
         #print("Touch:", x, y)
 
+    def raw(self):
+        '''
+        Returns all touch-data readable
+
+        Return:
+            p: pressure of the touch;  x * (z1 - z2) / z1 if z1>0 else None
+            x: x coordinate of finger 1
+            y: y coordinate of finger 1
+
+            z1: touchplate z1 position
+            z2: touchplate z2 position
+            t0: TEMP0 command result
+            t1: TEMP1 command result
+            b: GET_BATTERY command result
+            a: GET_AUX command result
+            d: number of milliseconds since this self.raw() routine last detected another touch
+        '''
+        return self._touch.raw_touch() # p, x, y, z1, z2, t0, t1, b, a, d = touch.raw_touch()
+
     def touches(self):
         '''
         Returns last stored touch data.

--- a/resources/xpt2046.py
+++ b/resources/xpt2046.py
@@ -6,7 +6,7 @@
 # https://github.com/rdagger/micropython-ili9341/
 
 """XPT2046 Touch module."""
-from time import sleep
+import time
 
 
 class Touch(object):
@@ -51,6 +51,7 @@ class Touch(object):
         self.x_max = x_max
         self.y_min = y_min
         self.y_max = y_max
+        self.last_touch=0
         self.x_multiplier = width / (x_max - x_min)
         self.x_add = x_min * -self.x_multiplier
         self.y_multiplier = height / (y_max - y_min)
@@ -81,7 +82,7 @@ class Touch(object):
                 if dev <= 50:  # Deviation should be under margin of 50
                     return self.normalize(meanx, meany)
             # get a new value
-            sample = self.raw_touch()  # get a touch
+            sample = self.raw_touch(True)  # get a touch
             if sample is None:
                 nsamples = 0    # Invalidate buff
             else:
@@ -89,7 +90,7 @@ class Touch(object):
                 buffptr = (buffptr + 1) % buf_length  # Incr, until rollover
                 nsamples = min(nsamples + 1, buf_length)  # Incr. until max
 
-            sleep(.05)
+            time.sleep(.05)
             timeout -= .05
         return None
 
@@ -97,14 +98,14 @@ class Touch(object):
         """Send X,Y values to passed interrupt handler."""
         if not pin.value() and not self.int_locked:
             self.int_locked = True  # Lock Interrupt
-            buff = self.raw_touch()
+            buff = self.raw_touch(True)
 
             if buff is not None:
                 x, y = self.normalize(*buff)
                 self.int_handler(x, y)
-            sleep(.1)  # Debounce falling edge
+            time.sleep(.1)  # Debounce falling edge
         elif pin.value() and self.int_locked:
-            sleep(.1)  # Debounce rising edge
+            time.sleep(.1)  # Debounce rising edge
             self.int_locked = False  # Unlock interrupt
 
     def normalize(self, x, y):
@@ -113,7 +114,7 @@ class Touch(object):
         y = int(self.y_multiplier * y + self.y_add)
         return x, y
 
-    def raw_touch(self):
+    def raw_touch(self,xyonly=False):
         """Read raw X,Y touch values.
 
         Returns:
@@ -121,10 +122,25 @@ class Touch(object):
         """
         x = self.send_command(self.GET_X)
         y = self.send_command(self.GET_Y)
-        if self.x_min <= x <= self.x_max and self.y_min <= y <= self.y_max:
-            return (x, y)
-        else:
-            return None
+        if xyonly:
+            if self.x_min <= x <= self.x_max and self.y_min <= y <= self.y_max:
+                return (x, y)
+            else:
+                return None
+        else: # some boards give spurious touch events, which can be filtered out by looking at pressure and timing
+            z1 = self.send_command(self.GET_Z1) # pressure
+            z2 = self.send_command(self.GET_Z2)
+            t0 = self.send_command(self.GET_TEMP0) # temperature
+            t1 = self.send_command(self.GET_TEMP1)
+            b = self.send_command(self.GET_BATTERY)
+            a = self.send_command(self.GET_AUX) # chip aux ADC input
+            p = x * (z1 - z2) / z1 if z1>0 else None # touch-pressure is a formula based on x
+            d = None
+            if p is not None:
+                now=time.ticks_ms()
+                d = time.ticks_diff(now, self.last_touch) # timediff since last (for debounce)
+                self.last_touch=now
+            return (p, x, y, z1, z2, t0, t1, b, a, d)
 
     def send_command(self, command):
         """Write command to XT2046 (MicroPython).


### PR DESCRIPTION
Thanks a million for your awesome work.

I want to have "sliders", so I needed more than just "touch event detection", plus my board issues spurious events occasionally, so I've updated the touch-driver to return all the data needed to solve all my problems.

This update makes debounce and spurious-event-rejection possible, and allows polling for when we want to let users "drag things around" (in my case - it's a light-dimmer with an icon of a DJ slider control which they can move around).

This is also a test of whether or not PRs get merged.  I'm planning a big update to the graphics code so we can use "rotate" properly (so you specify what rotation to use during init, and all graphics work on that orientation from then on).  I'm not sure whether to contribute these new features (a lot of work), or to just do a local version for myself (so I can skip doing the ones I do not need - like polygons etc).  No point doing lots of work if nobody wants it of course...

I'm also investigating how to add st7789 support, since these are the chips in the latest batch of CYD's flooding aliexpress